### PR TITLE
feat: add multi-base battles and unit collisions

### DIFF
--- a/rts.html
+++ b/rts.html
@@ -105,7 +105,7 @@
       this.hpBar.clear();
       this.hpBar.fillStyle(0x000000, 0.6).fillRoundedRect(this.x-30, this.y+34, 60, 8, 3);
       this.hpBar.fillStyle(pct>0.5?0x19d4a6:pct>0.25?0xffb020:0xff6b6b, 1).fillRoundedRect(this.x-30, this.y+34, 60*pct, 8, 3);
-      if(this.isPlayer) ui.basehp.textContent = Math.round(pct*100);
+      if(this.isPlayer && this === this.scene.playerBase) ui.basehp.textContent = Math.round(pct*100);
     }
     damage(d){ this.hp=Math.max(0,this.hp-d); this.updateHpBar(); if(this.hp<=0 && !this.dead){ this.dead=true; this.text.setText('💥'); this.scene.onBaseDestroyed(this); } }
   }
@@ -138,9 +138,13 @@
           if(dist > s.range*0.85){ s._goTo(s.target.x, s.target.y, dt); } else { s.vx=s.vy=0; s._attackTick(dt, s.target); }
         } else if(s.order.kind==='harvest'){
           const m=s.order.m; if(!m || m.dead){ s.order=null; return; }
-          if(s.carry>=s.cap){ // return to base
-            const b=s.scene.playerBase; const dx=b.x-s.x, dy=b.y-s.y, dist=Math.hypot(dx,dy);
-            if(dist>24) s._goTo(b.x,b.y,dt); else { s.scene.addMinerals(s.carry); s.carry=0; }
+          if(s.carry>=s.cap){ // return to nearest base
+            const bases = s.scene.playerBases.filter(b=>!b.dead);
+            if(bases.length){
+              let b=bases[0], best=Phaser.Math.Distance.Between(s.x,s.y,b.x,b.y);
+              for(const nb of bases){ const d=Phaser.Math.Distance.Between(s.x,s.y,nb.x,nb.y); if(d<best){ best=d; b=nb; }}
+              if(best>24) s._goTo(b.x,b.y,dt); else { s.scene.addMinerals(s.carry); s.carry=0; }
+            }
           } else {
             const dx=m.x-s.x, dy=m.y-s.y, dist=Math.hypot(dx,dy);
             if(dist>22){ s._goTo(m.x,m.y,dt); s.gathering=false; }
@@ -156,7 +160,7 @@
         const nearUnit = this.scene.findNearestEnemyUnit(this.x, this.y, this.isPlayer, 160);
         if(nearUnit){ this.attack(nearUnit); }
         else if((!hasDamage(this.target) || this.target.dead) && this.type!=='worker'){
-          const enemyAny = this.scene.findNearestEnemyAny(this.x, this.y, this.isPlayer, 220);
+          const enemyAny = this.scene.findNearestEnemyAny(this.x, this.y, this.isPlayer);
           if(enemyAny) this.attack(enemyAny);
         }
       }
@@ -182,21 +186,32 @@
       for(let y=0;y<MAP_H;y+=200){ g.lineBetween(0,y,MAP_W,y); }
 
       // Bases
-      this.playerBase = new Base(this, 220, MAP_H/2, true); this.playerBase.base=true;
-      this.enemyBase  = new Base(this, MAP_W-220, MAP_H/2, false); this.enemyBase.base=true;
+      this.playerBases = [
+        new Base(this, 220, MAP_H/2 - 200, true),
+        new Base(this, 220, MAP_H/2, true),
+        new Base(this, 220, MAP_H/2 + 200, true)
+      ];
+      this.enemyBases = [
+        new Base(this, MAP_W-220, MAP_H/2 - 200, false),
+        new Base(this, MAP_W-220, MAP_H/2, false),
+        new Base(this, MAP_W-220, MAP_H/2 + 200, false)
+      ];
+      this.playerBases.forEach(b=>b.base=true); this.enemyBases.forEach(b=>b.base=true);
+      this.playerBase = this.playerBases[1];
+      this.enemyBase = this.enemyBases[1];
 
       // Camera initiale : léger dé-zoom + centrage
       const cam = this.cameras.main; cam.setZoom(0.9); cam.centerOn(MAP_W/2, MAP_H/2);
 
-      // Minerals field
+      // Minerals field (closer & ordered near central base)
       for(let i=0;i<8;i++){
-        const x = 540 + (i%4)*140 + (Math.random()*30-15);
-        const y = MAP_H/2 - 140 + Math.floor(i/4)*140 + (Math.random()*30-15);
+        const x = 400 + (i%4)*120 + (Math.random()*30-15);
+        const y = MAP_H/2 - 120 + Math.floor(i/4)*120 + (Math.random()*30-15);
         this.minerals.push(new Mineral(this,x,y, 400+Math.floor(Math.random()*200)));
       }
 
       // Starting units
-      this.playerMinerals = 100; this.updateHud();
+      this.playerMinerals = 200; this.updateHud();
       for(let i=0;i<3;i++) this.spawnUnit(true,'worker', this.playerBase.x+60+i*28, this.playerBase.y+40);
 
       // Input & selection
@@ -267,6 +282,20 @@
       // Units update
       this.units.forEach(u=>u.update(dt));
       this.enemyUnits.forEach(u=>u.update(dt));
+      // simple collision avoidance between units
+      const all = this.units.concat(this.enemyUnits);
+      for(let i=0;i<all.length;i++){
+        for(let j=i+1;j<all.length;j++){
+          const a=all[i], b=all[j]; if(a.dead||b.dead) continue;
+          const dx=a.x-b.x, dy=a.y-b.y; const dist=Math.hypot(dx,dy); const min=24;
+          if(dist>0 && dist<min){
+            const overlap=(min-dist)/2; const nx=dx/dist, ny=dy/dist;
+            a.x+=nx*overlap; a.y+=ny*overlap; b.x-=nx*overlap; b.y-=ny*overlap;
+            a.text.setPosition(a.x,a.y); b.text.setPosition(b.x,b.y);
+            a.drawRing(); b.drawRing(); a.updateHpBar(); b.updateHpBar();
+          }
+        }
+      }
       // cleanup
       this.units = this.units.filter(u=>!u.dead);
       this.enemyUnits = this.enemyUnits.filter(u=>!u.dead);
@@ -296,7 +325,8 @@
       const enemyUnder = this.enemyUnderCursor(world.x, world.y, true, 44);
       if(hasDamage(enemyUnder)){ this.selected.forEach(u=>u.attack(enemyUnder)); ui.showToast('🎯 Attaquer'); return; }
       // 2) Base ennemie si cliquée
-      if(Phaser.Math.Distance.Between(world.x,world.y,this.enemyBase.x,this.enemyBase.y)<50){ this.selected.forEach(u=>u.attack(this.enemyBase)); ui.showToast('🎯 Attaquer base'); return; }
+      const baseClicked = this.enemyBases.find(b=>!b.dead && Phaser.Math.Distance.Between(world.x,world.y,b.x,b.y)<50);
+      if(baseClicked){ this.selected.forEach(u=>u.attack(baseClicked)); ui.showToast('🎯 Attaquer base'); return; }
       // 3) Minerais
       const mineral = this.minerals.find(m=>Phaser.Math.Distance.Between(world.x,world.y,m.x,m.y)<24);
       if(mineral){ this.selected.filter(u=>u.type==='worker').forEach(u=>u.harvest(mineral)); ui.showToast('⛏️ Miner'); if(this.selected.some(u=>u.type==='worker')) return; }
@@ -317,12 +347,17 @@
     spawnHit(x,y){ const t=this.add.text(x,y,'💥',{fontSize:18}).setOrigin(0.5).setDepth(9); this.tweens.add({ targets:t, y:y-10, alpha:0, duration:300, onComplete:()=>t.destroy()}); }
 
     spawnEnemyWave(){
+      const spawnBase = this.enemyBases[Phaser.Math.Between(0, this.enemyBases.length-1)];
       const s = this.spawnUnit(
         false, 'soldier',
-        this.enemyBase.x - 60 + Phaser.Math.Between(-10,10),
-        this.enemyBase.y + Phaser.Math.Between(-30,30)
+        spawnBase.x - 60 + Phaser.Math.Between(-10,10),
+        spawnBase.y + Phaser.Math.Between(-30,30)
       );
-      s.attack(this.playerBase);
+      const targets = this.playerBases.filter(b=>!b.dead);
+      if(targets.length){
+        const tgt = targets[Phaser.Math.Between(0, targets.length-1)];
+        s.attack(tgt);
+      }
     }
 
     // Helpers de ciblage
@@ -332,14 +367,18 @@
     }
     findNearestEnemyAny(x,y, isForPlayer, within=Infinity){
       const listUnits = (isForPlayer? this.enemyUnits : this.units).filter(e=>hasDamage(e));
-      const base = isForPlayer? this.enemyBase : this.playerBase;
-      const list = listUnits.concat(hasDamage(base)?[base]:[]);
+      const bases = (isForPlayer? this.enemyBases : this.playerBases).filter(b=>hasDamage(b) && !b.dead);
+      const list = listUnits.concat(bases);
       let best=null, bd=within; for(const e of list){ if(e.dead) continue; const d=Phaser.Math.Distance.Between(x,y,e.x,e.y); if(d<bd){ bd=d; best=e; }} return best;
     }
 
     onBaseDestroyed(base){
-      if(base.isPlayer){ ui.showToast('Défaite… 😵', 3000); this.scene.pause(); this.time.delayedCall(50,()=>alert('Défaite… Votre base a été détruite.')); }
-      else { ui.showToast('Victoire ! 🎉', 3000); this.scene.pause(); this.time.delayedCall(50,()=>alert('Victoire ! Vous avez détruit la base ennemie.')); }
+      if(base.isPlayer){
+        if(this.playerBases.every(b=>b.dead)){ ui.showToast('Défaite… 😵', 3000); this.scene.pause(); this.time.delayedCall(50,()=>alert('Défaite… Vos bases ont été détruites.')); }
+      }
+      else {
+        if(this.enemyBases.every(b=>b.dead)){ ui.showToast('Victoire ! 🎉', 3000); this.scene.pause(); this.time.delayedCall(50,()=>alert('Victoire ! Vous avez détruit toutes les bases ennemies.')); }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- support three bases per side with victory/defeat once all bases destroyed
- arrange minerals near central base and start with 200 crystals
- enemy waves target random bases and units now collide instead of overlapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b764d48483238a4ab9e1c4e5dafb